### PR TITLE
refactor: remove redundant text from members count display

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -139,7 +139,7 @@ export default function Members() {
                 </div>
                 <div className="ml-auto">
                   <span className="text-foreground/60 bg-white/5 px-3 py-1 rounded-full text-sm font-medium">
-                    {members.length} members
+                    {members.length}
                   </span>
                 </div>
               </div>


### PR DESCRIPTION
## Description:
/about: the text X members was not responsive in the mobile view.

### Fix: 
Removed the text 'members'. Only the count is shown now. 

### Linked Issue:
Fixes #2 